### PR TITLE
[feat] : 마이페이지, 프로필 페이지 PC ver UI 구현

### DIFF
--- a/src/components/common/input/Input.Style.ts
+++ b/src/components/common/input/Input.Style.ts
@@ -24,6 +24,12 @@ export const Input = styled.input<{ $isError: boolean }>`
     outline: none;
     border: 1px solid ${({ $isError, theme }) => ($isError ? '#f00' : theme.colors.gray50)};
   }
+
+  ${(props) => props.theme.breakpoints.min} {
+    max-width: 30.625rem;
+    padding: 0.75rem;
+    font-size: 1.125rem;
+  }
 `;
 
 export const ErrorMessage = styled.p`

--- a/src/components/common/list/List.Style.ts
+++ b/src/components/common/list/List.Style.ts
@@ -10,6 +10,10 @@ export const List = styled.section`
   border-radius: 0.5rem;
   background-color: ${({ theme }) => theme.colors.white};
   cursor: pointer;
+
+  ${(props) => props.theme.breakpoints.min} {
+    height: 8.8125rem;
+  }
 `;
 
 export const ChipContainer = styled.div`

--- a/src/components/common/selectbox/SelectBox.Style.ts
+++ b/src/components/common/selectbox/SelectBox.Style.ts
@@ -5,6 +5,10 @@ export const Container = styled.div`
   flex-direction: column;
   gap: 0.5rem;
   cursor: pointer;
+
+  ${(props) => props.theme.breakpoints.min} {
+    gap: 0.625rem;
+  }
 `;
 
 export const SelectBox = styled.div<{ open: boolean }>`
@@ -19,6 +23,14 @@ export const SelectBox = styled.div<{ open: boolean }>`
   color: ${({ theme }) => theme.colors.gray900};
   font-size: 1rem;
   line-height: 145%;
+
+  ${(props) => props.theme.breakpoints.min} {
+    gap: 0.625rem;
+    max-width: 30.625rem;
+    height: 3.125rem;
+    padding: 0.75rem;
+    font-size: 1.125rem;
+  }
 `;
 
 export const SelectText = styled.span<{ $hasValue: boolean }>`
@@ -28,7 +40,7 @@ export const SelectText = styled.span<{ $hasValue: boolean }>`
 export const Icon = styled.img`
   position: absolute;
   top: 0.75rem;
-  right: 0.5rem;
+  right: 0.75rem;
 `;
 
 export const Option = styled.div`
@@ -39,9 +51,18 @@ export const Option = styled.div`
   gap: 0.625rem;
   border-radius: 0.5rem;
   border: 1px solid ${({ theme }) => theme.colors.blue200};
+
+  ${(props) => props.theme.breakpoints.min} {
+    max-width: 30.625rem;
+    padding: 0.75rem 0.875rem;
+  }
 `;
 
 export const Text = styled.div`
   font-size: 1rem;
   line-height: 145%;
+
+  ${(props) => props.theme.breakpoints.min} {
+    font-size: 1.125rem;
+  }
 `;

--- a/src/components/editProfile/EditProfile.Style.ts
+++ b/src/components/editProfile/EditProfile.Style.ts
@@ -14,4 +14,8 @@ export const Edit = styled.div`
 
 export const Title = styled.h5`
   line-height: 140%;
+
+  ${(props) => props.theme.breakpoints.min} {
+    font-size: 1.25rem;
+  }
 `;

--- a/src/components/home/content/Content.Style.ts
+++ b/src/components/home/content/Content.Style.ts
@@ -15,6 +15,7 @@ export const Content = styled.div`
     padding: 0rem;
     border-radius: 0rem;
     gap: 0.75rem;
+    height: auto;
   }
 `;
 

--- a/src/components/layout/header/Header.style.ts
+++ b/src/components/layout/header/Header.style.ts
@@ -5,6 +5,10 @@ export const Header = styled.header`
   width: 100%;
   height: 3.75rem;
   padding: 0.875rem 0rem;
+
+  ${(props) => props.theme.breakpoints.min} {
+    height: auto;
+  }
 `;
 
 export const Icon = styled.img`

--- a/src/components/my/profile/Profile.Style.ts
+++ b/src/components/my/profile/Profile.Style.ts
@@ -6,6 +6,14 @@ export const Container = styled.section`
   gap: 1.25rem;
   padding: 1.375rem 1.9375rem 2.25rem;
   background-color: ${({ theme }) => theme.colors.white};
+
+  ${(props) => props.theme.breakpoints.min} {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    justify-content: space-between;
+    padding: 0;
+  }
 `;
 
 export const Profile = styled.div`
@@ -13,6 +21,13 @@ export const Profile = styled.div`
   width: 100%;
   justify-content: space-between;
   align-items: center;
+
+  ${(props) => props.theme.breakpoints.min} {
+    display: flex;
+    width: auto;
+    flex-direction: column;
+    gap: 2.5rem;
+  }
 `;
 
 export const TextContainer = styled.div`
@@ -20,15 +35,30 @@ export const TextContainer = styled.div`
   flex-direction: column;
   gap: 0.25rem;
   color: #373737;
+
+  ${(props) => props.theme.breakpoints.min} {
+    gap: 0.5rem;
+  }
 `;
 
 export const Text = styled.h6`
   line-height: 140%;
+
+  ${(props) => props.theme.breakpoints.min} {
+    font-size: 1.5rem;
+    line-height: 135%;
+  }
 `;
 
 export const SubText = styled.p`
   font-size: 0.8125rem;
   line-height: 145%;
+
+  ${(props) => props.theme.breakpoints.min} {
+    font-size: 1.25rem;
+    font-weight: 600;
+    line-height: 140%;
+  }
 `;
 
 export const Button = styled.button`
@@ -40,6 +70,20 @@ export const Button = styled.button`
   font-weight: 500;
   line-height: 150%;
   cursor: pointer;
+
+  ${(props) => props.theme.breakpoints.min} {
+    font-size: 1rem;
+  }
+`;
+
+export const Detail = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+
+  ${(props) => props.theme.breakpoints.min} {
+    gap: 0.875rem;
+  }
 `;
 
 export const DIV = styled.div`
@@ -47,6 +91,11 @@ export const DIV = styled.div`
   width: 100%;
   height: 6.75rem;
   background-color: ${({ theme }) => theme.colors.blue50};
+
+  ${(props) => props.theme.breakpoints.min} {
+    width: 24.625rem;
+    height: 6.875rem;
+  }
 `;
 
 export const Record = styled.div`
@@ -62,4 +111,9 @@ export const Record = styled.div`
   font-size: 1rem;
   font-weight: 600;
   line-height: 140%;
+
+  ${(props) => props.theme.breakpoints.min} {
+    height: 3.75rem;
+    font-size: 1.125rem;
+  }
 `;

--- a/src/components/my/profile/Profile.tsx
+++ b/src/components/my/profile/Profile.tsx
@@ -37,14 +37,16 @@ export const Profile = () => {
           내 프로필 수정하기
         </S.Button>
       </S.Profile>
-      <S.DIV /> {/* 임시 작업 */}
-      <S.Record
-        onClick={() => {
-          navigate('/list');
-        }}
-      >
-        {user.nickname}경험을 {user.recordCount}개 모았어요
-      </S.Record>
+      <S.Detail>
+        <S.DIV /> {/* 임시 작업 */}
+        <S.Record
+          onClick={() => {
+            navigate('/list');
+          }}
+        >
+          {user.nickname}님의 경험을 {user.recordCount}개 모았어요
+        </S.Record>
+      </S.Detail>
     </S.Container>
   );
 };

--- a/src/components/my/settings/SettingItem.Style.ts
+++ b/src/components/my/settings/SettingItem.Style.ts
@@ -7,16 +7,16 @@ export const Item = styled.div`
   width: 100%;
 `;
 
-export const TextContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  font-weight: 500;
-`;
-
 export const Text = styled.span`
   font-size: 0.875rem;
+  font-weight: 500;
   color: #070707;
+
+  ${(props) => props.theme.breakpoints.min} {
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 145%;
+  }
 `;
 
 export const Icon = styled.img`

--- a/src/components/my/settings/SettingItem.tsx
+++ b/src/components/my/settings/SettingItem.tsx
@@ -8,9 +8,9 @@ interface SettingItemProps {
 
 export const SettingItem = ({ children, onClick }: SettingItemProps) => {
   return (
-    <S.Item>
+    <S.Item onClick={onClick}>
       <S.Text>{children}</S.Text>
-      <S.Icon src={RightArrowIcon} alt="rightArrow" onClick={onClick} />
+      <S.Icon src={RightArrowIcon} alt="rightArrow" />
     </S.Item>
   );
 };

--- a/src/components/my/settings/SettingItem.tsx
+++ b/src/components/my/settings/SettingItem.tsx
@@ -9,9 +9,7 @@ interface SettingItemProps {
 export const SettingItem = ({ children, onClick }: SettingItemProps) => {
   return (
     <S.Item>
-      <S.TextContainer>
-        <S.Text>{children}</S.Text>
-      </S.TextContainer>
+      <S.Text>{children}</S.Text>
       <S.Icon src={RightArrowIcon} alt="rightArrow" onClick={onClick} />
     </S.Item>
   );

--- a/src/components/my/settings/Settings.Style.ts
+++ b/src/components/my/settings/Settings.Style.ts
@@ -6,6 +6,10 @@ export const Container = styled.div`
   width: 100%;
   padding: 1.875rem 1.25rem 0rem;
   gap: 1.25rem;
+
+  ${(props) => props.theme.breakpoints.min} {
+    padding: 0rem;
+  }
 `;
 
 export const Content = styled.section`
@@ -16,4 +20,8 @@ export const Content = styled.section`
   gap: 1.25rem;
   background-color: ${({ theme }) => theme.colors.white};
   border-radius: 1.25rem;
+
+  ${(props) => props.theme.breakpoints.min} {
+    border: 1px solid ${({ theme }) => theme.colors.gray100};
+  }
 `;

--- a/src/pages/editProfile/EditProfilePage.Style.ts
+++ b/src/pages/editProfile/EditProfilePage.Style.ts
@@ -19,7 +19,7 @@ export const Content = styled.div`
     justify-content: flex-start;
     gap: 2.8125rem;
     margin-top: 5rem;
-    padding: 0rem 9.7rem;
+    padding: 0rem 4.75rem;
     height: auto;
   }
 `;

--- a/src/pages/editProfile/EditProfilePage.Style.ts
+++ b/src/pages/editProfile/EditProfilePage.Style.ts
@@ -1,19 +1,42 @@
 import styled from 'styled-components';
 
+export const TabBarContainer = styled.div`
+  ${(props) => props.theme.breakpoints.min} {
+    display: none;
+  }
+`;
+
 export const Content = styled.div`
-  position: absolute;
-  top: 3.75rem;
-  left: 0;
+  margin-top: 3.5rem;
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
+  height: calc(100vh - 3.5rem);
   width: 100%;
-  height: calc(100vh - 3.75rem);
   padding: 1.75rem 1.25rem;
+
+  ${(props) => props.theme.breakpoints.min} {
+    justify-content: flex-start;
+    gap: 2.8125rem;
+    margin-top: 5rem;
+    padding: 0rem 9.7rem;
+    height: auto;
+  }
+`;
+
+export const Title = styled.h3`
+  line-height: 135%;
+
+  ${(props) => props.theme.breakpoints.max} {
+    display: none;
+  }
 `;
 
 export const ButtonStyle = styled.div`
-  width: calc(100% - 2.5rem);
-  position: absolute;
-  bottom: 2.5rem;
-  left: 1.25rem;
+  ${(props) => props.theme.breakpoints.min} {
+    width: 11.0625rem;
+    position: absolute;
+    top: 38rem;
+    left: 60rem;
+  }
 `;

--- a/src/pages/editProfile/EditProfilePage.Style.ts
+++ b/src/pages/editProfile/EditProfilePage.Style.ts
@@ -24,7 +24,7 @@ export const Content = styled.div`
   }
 `;
 
-export const Title = styled.h3`
+export const Title = styled.h2`
   line-height: 135%;
 
   ${(props) => props.theme.breakpoints.max} {

--- a/src/pages/editProfile/EditProfilePage.tsx
+++ b/src/pages/editProfile/EditProfilePage.tsx
@@ -40,8 +40,12 @@ export const EditProfilePage = () => {
 
   return (
     <div>
-      <TabBar centerText="프로필 수정" />
+      <S.TabBarContainer>
+        <TabBar centerText="프로필 수정" />
+      </S.TabBarContainer>
+
       <S.Content>
+        <S.Title>프로필 수정</S.Title>
         <EditProfile
           nickname={nickname}
           onChangeNickname={onChangeNickname}

--- a/src/pages/myPage/MyPage.Style.ts
+++ b/src/pages/myPage/MyPage.Style.ts
@@ -5,7 +5,7 @@ export const Container = styled.div`
     display: flex;
     flex-direction: column;
     gap: 2.5rem;
-    padding: 5rem 12.3125rem 0rem;
+    padding: 5rem 15rem 0rem 4.75rem;
   }
 `;
 

--- a/src/pages/myPage/MyPage.Style.ts
+++ b/src/pages/myPage/MyPage.Style.ts
@@ -1,15 +1,42 @@
 import styled from 'styled-components';
 
-export const Header = styled.div`
+export const Container = styled.div`
+  ${(props) => props.theme.breakpoints.min} {
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+    padding: 5rem 12.3125rem 0rem;
+  }
+`;
+
+export const MobileHeader = styled.div`
   background-color: ${({ theme }) => theme.colors.white};
   width: 100%;
   padding: 0rem 1.25rem;
   height: 3.75rem;
   border-bottom: 1px solid ${({ theme }) => theme.colors.gray100};
+
+  ${(props) => props.theme.breakpoints.min} {
+    display: none;
+  }
+`;
+
+export const PcHeader = styled.h2`
+  line-height: 140%;
+  ${(props) => props.theme.breakpoints.max} {
+    display: none;
+  }
 `;
 
 export const Content = styled.div`
   width: 100%;
   height: calc(100vh - 3.75rem);
   background-color: #f5f5f5;
+  ${(props) => props.theme.breakpoints.min} {
+    display: flex;
+    flex-direction: column;
+    background-color: ${({ theme }) => theme.colors.white};
+    height: auto;
+    gap: 5rem;
+  }
 `;

--- a/src/pages/myPage/MyPage.tsx
+++ b/src/pages/myPage/MyPage.tsx
@@ -57,10 +57,11 @@ export const MyPage = () => {
   };
 
   return (
-    <>
-      <S.Header>
+    <S.Container>
+      <S.MobileHeader>
         <Header onClick={toggleSideBar} title="마이페이지" />
-      </S.Header>
+      </S.MobileHeader>
+      <S.PcHeader>마이페이지</S.PcHeader>
       <S.Content>
         <Profile />
         <Settings onClickLogout={toggleLogout} onClickDeleteId={toggleDeleteId} />
@@ -91,6 +92,6 @@ export const MyPage = () => {
       )}
       {confirmDelete && <ConfirmModal onClick={toggleConfirmDelete} />}
       {openSideBar && <SideBar onClick={toggleSideBar} />}
-    </>
+    </S.Container>
   );
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

>  연관된 이슈 번호를 작성해주세요.
#126 

## 📝작업 내용

> 작업한 내용을 작성해주세요.
마이페이지, 프로필 페이지 PC ver UI 구현

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/0f782e53-bfba-4c9b-abff-f6cd9f501134)
![image](https://github.com/user-attachments/assets/9eae5750-6314-4f2d-81d5-8dcee2a05cfa)
![image](https://github.com/user-attachments/assets/d1264c04-5189-44f9-be08-e99e479bb31e)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
1. 피그마 시안대로 작업하게 될 경우 피씨 버전에서 예쁘지가 않아요... 임의로 제 피씨 환경에서 괜찮은지 확인 후 만들어봤는데 어떤가요? 피그마 디자인과 별로 다르지 않을 경우 이대로 진행하는 것도 좋을 것 같아요
2. 마이페이지 글씨 프로필 수정 글씨 크기 통일에 대해 어떻게 생각하시나요? 4px 차이
3. 마이페이지와 프로필 수정 페이지 패딩이 각각 달라서 페이지 이동 시 어색한 부분이 있는데 이를 통일해본 것입니당 혹시 위 스크린샷과 이것 중 어느 것이 더 나은가요? 더 나은 방향으로 수정하겠습니다!
1) 프로필 편집과 동일하게
![image](https://github.com/user-attachments/assets/da1e8c76-acdd-4c3f-abe6-93e3ca2608b4)
![image](https://github.com/user-attachments/assets/02be1dd2-7107-415f-a368-7d8aebf6d84f)

2) 마이페이지와 동일하게
![image](https://github.com/user-attachments/assets/04509777-0038-42c2-8d51-a8d88f48e2de)
![image](https://github.com/user-attachments/assets/95a73016-73c8-4bd2-a9e6-25d214cc9006)

3) 그냥 맨 위처럼 하자!

-> 디자인 왼쪽 패딩 76px로 통일 확인 받았습니다!! 
