### PR TITLE
[refactor] : 채팅/메모 다시보기 시 여러 기능 비활성화 & api 재요청

### DIFF
--- a/src/api/Chat.ts
+++ b/src/api/Chat.ts
@@ -94,46 +94,15 @@ export const deleteChat = async (chatRoomId: number) => {
 };
 
 /** [3.5] 채팅 경험 요약하기 */
-export class CustomError extends Error {
-  code: string;
-
-  constructor(code: string, message: string) {
-    super(message);
-    this.code = code;
-  }
-}
-
 export const getSummary = async (chatRoomId: number) => {
   try {
     const response = await api.get(`/api/records/chat/${chatRoomId}/summary`);
-
-    if (!response.data.is_success) {
-      switch (response.data.code) {
-        case 'E0305_OVERFLOW_SUMMARY_TITLE':
-          throw new CustomError(response.data.code, '제목은 50자 이내여야 합니다. ' + response.data.message);
-        case 'E0305_OVERFLOW_SUMMARY_CONTENT':
-          throw new CustomError(response.data.code, '경험 요약 내용은 500자 이내여야 합니다. ' + response.data.message);
-        case 'E0305_INVALID_CHAT_SUMMARY':
-          throw new CustomError(response.data.code, '채팅 경험 요약 파싱 중 오류가 발생했습니다. ' + response.data.message);
-        case 'E0305_NO_RECORD':
-          alert('경험 기록의 내용이 충분하지 않습니다. 내용을 더 자세히 작성해주세요.');
-          throw new CustomError(response.data.code, '경험 기록의 내용이 부족합니다.');
-        default:
-          throw new CustomError(response.data.code, response.data.message || '요약 처리 중 알 수 없는 오류가 발생했습니다.');
-      }
-    }
-
     return response.data.data;
   } catch (error) {
-    if (error instanceof CustomError) {
-      console.error(`Code: ${error.code}, Message: ${error.message}`);
-    } else {
-      console.error(error);
-    }
+    console.error(error);
     throw error;
   }
 };
-
 
 /** [3.6] 채팅 임시 저장 유무 조회 */
 

--- a/src/components/chat/ChatBox.tsx
+++ b/src/components/chat/ChatBox.tsx
@@ -4,9 +4,10 @@ import * as S from './ChatBox.Style';
 
 interface ChatBoxProps {
   onSubmit: (message: string) => void;
+  isReviewMode: boolean;
 }
 
-export const ChatBox = ({ onSubmit }: ChatBoxProps) => {
+export const ChatBox = ({ onSubmit, isReviewMode }: ChatBoxProps) => {
   const [message, setMessage] = useState('');
 
   const handleSend = (event: React.FormEvent<HTMLFormElement>) => {
@@ -26,9 +27,10 @@ export const ChatBox = ({ onSubmit }: ChatBoxProps) => {
           type="text"
           value={message}
           onChange={(e) => setMessage(e.target.value)}
-          placeholder="내용을 입력해 주세요"
+          placeholder={isReviewMode ? '채팅을 입력할 수 없습니다.' : '내용을 입력해 주세요'}
+          disabled={isReviewMode}
         />
-        <S.ChatBoxButton type="submit" $hasMessage={hasMessage}>
+        <S.ChatBoxButton type="submit" $hasMessage={hasMessage} disabled={isReviewMode}>
           <img src={UpArrowIcon} alt="Send" />
         </S.ChatBoxButton>
       </S.ChatBoxForm>

--- a/src/pages/chatPage/ChatPage.Style.ts
+++ b/src/pages/chatPage/ChatPage.Style.ts
@@ -29,5 +29,5 @@ export const InputContainer = styled.div`
   bottom: 0;
   left: 0;
   right: 0;
-  width: 100%
+  width: 100%;
 `;

--- a/src/pages/chatPage/ChatPage.tsx
+++ b/src/pages/chatPage/ChatPage.tsx
@@ -70,7 +70,7 @@ export const ChatPage = () => {
     const fetchTmpChatData = async () => {
       try {
         // review-chat 경로로 접근한 경우에만 임시저장 확인하지 않음
-        if (window.location.pathname.includes('review-chat')) return;
+        if (isReviewMode) return;
 
         // 임시 저장된 채팅 기록이 있는지 확인
         const tmpChatData = await checkTmpChat();

--- a/src/pages/chatPage/ChatPage.tsx
+++ b/src/pages/chatPage/ChatPage.tsx
@@ -18,6 +18,8 @@ interface Message {
 }
 
 export const ChatPage = () => {
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
   const firstChat = localStorage.getItem('firstChat') || '안녕하세요! 경험을 작성해주세요.';
   const formattedFirstChat = firstChat.replace(/\n/g, '<br>');
   const { id } = useParams();
@@ -35,8 +37,7 @@ export const ChatPage = () => {
   const [isLoadTempModalOpen, setIsLoadTempModalOpen] = useState(false);
   const [showToast, setShowToast] = useState(false);
   const [showGuideButton, setShowGuideButton] = useState(true);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
-  const navigate = useNavigate();
+  const isReviewMode = window.location.pathname.includes('review-chat');
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -307,7 +308,7 @@ export const ChatPage = () => {
 
   return (
     <>
-      <TabBar rightText="완료하기" onClickBackIcon={handleTemporarySave} onClick={() => setIsModalOpen(true)} isDisabled={messages.length === 0} />
+      <TabBar rightText={isReviewMode ? "" : "완료하기"} onClickBackIcon={handleTemporarySave} onClick={() => setIsModalOpen(true)} isDisabled={messages.length === 0} />
       {isModalOpen && (
         <DetailModal
           text="기록을 완료할까요?"
@@ -349,7 +350,7 @@ export const ChatPage = () => {
         <div ref={messagesEndRef} />
         <S.InputContainer>
           {showGuideButton && <GuideButton text="🤔 경험을 어떻게 말해야 할지 모르겠어요" onClick={handleGuideButtonClick} />}
-          <ChatBox onSubmit={handleSendMessage} />
+          <ChatBox onSubmit={handleSendMessage} isReviewMode={isReviewMode} />
         </S.InputContainer>
       </S.ChatContainer>
     </>

--- a/src/pages/chatPage/ChatPage.tsx
+++ b/src/pages/chatPage/ChatPage.tsx
@@ -9,7 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import * as S from './ChatPage.Style';
 import ToastMessage from '@/components/chat/ToastMessage';
 import { LoadingDots } from '@components/chat/LodingDots';
-import { postAiChat, postTmpChat, checkTmpChat, getChat, getSummary, deleteChat, postChat, CustomError } from '@/api/Chat';
+import { postAiChat, postTmpChat, checkTmpChat, getChat, getSummary, deleteChat, postChat } from '@/api/Chat';
 
 interface Message {
   message: string;
@@ -236,35 +236,35 @@ export const ChatPage = () => {
           return;
         }
       } catch (error: any) {
-        if (error instanceof CustomError) {
-          switch (error.code) {
-            case 'E0305_OVERFLOW_SUMMARY_TITLE':
-            case 'E0305_OVERFLOW_SUMMARY_CONTENT':
-            case 'E0305_INVALID_CHAT_SUMMARY':
-              // 1초 대기 후 재시도
-              await new Promise((resolve) => setTimeout(resolve, 1000));
-              const retryResponse = await getSummary(chatRoomId);
 
-              if (retryResponse) {
-                navigate('/record-complete', {
-                  state: { chatRoomId, summary: retryResponse.content, title: retryResponse.title },
-                });
-                return;
-              }
-              break;
-            case 'E0305_NO_RECORD':
-              // 내용 부족 에러: 알림 후 종료
-              alert('경험 기록의 내용이 충분하지 않습니다. 내용을 더 자세히 작성해주세요.');
+        // Axios 에러에서 서버 응답 코드 확인
+        const errorCode = error.response?.data?.code || error.code;
+
+        switch (errorCode) {
+          case 'E0305_OVERFLOW_SUMMARY_TITLE':
+          case 'E0305_OVERFLOW_SUMMARY_CONTENT':
+          case 'E0305_INVALID_CHAT_SUMMARY':
+            // 1초 대기 후 재시도
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+            const retryResponse = await getSummary(chatRoomId);
+
+            if (retryResponse) {
+              navigate('/record-complete', {
+                state: { chatRoomId, summary: retryResponse.content, title: retryResponse.title },
+              });
               return;
-            default:
-              throw error; // 예상하지 못한 에러
-          }
-        } else {
-          throw error; // CustomError가 아닌 다른 에러
+            }
+            break;
+          case 'E0305_NO_RECORD':
+            // 내용 부족 에러: 알림 후 종료
+            alert('경험 기록의 내용이 충분하지 않습니다. 내용을 더 자세히 작성해주세요.');
+            return;
+          default:
+            throw error; // 예상하지 못한 에러
         }
       }
     } catch (error) {
-      console.error(error); // 디버깅용 로그
+      console.error(error);
       alert('완료 처리 중 오류가 발생했습니다. 다시 시도해주세요.');
     }
   };

--- a/src/pages/memoPage/MemoPage.Style.ts
+++ b/src/pages/memoPage/MemoPage.Style.ts
@@ -1,6 +1,10 @@
 import styled from 'styled-components';
 import { Input as OriginalInput } from '@components/common/input/Input';
 
+interface ReviewModeProps {
+  $isReviewMode: boolean;
+}
+
 export const Container = styled.div`
   display: flex;
   flex-direction: column;
@@ -46,12 +50,13 @@ export const SubTitle = styled.h4`
   white-space: pre-wrap;
 `;
 
-export const Label = styled.p`
+export const Label = styled.p<ReviewModeProps>`
   color: ${({ theme }) => theme.colors.gray900};
   font-size: 1rem;
   font-weight: 400;
   line-height: 145%;
   margin-left: 0.5rem;
+  ${({ $isReviewMode }) => $isReviewMode && 'display: none;'}
 `;
 
 export const Form = styled.form`
@@ -80,13 +85,13 @@ export const Line = styled.div`
   margin-bottom: 0.625rem;
 `;
 
-export const Content = styled.textarea`
+export const Content = styled.textarea<ReviewModeProps>`
   font-family: 'Pretendard';
   font-size: 1rem;
   font-weight: 400;
   line-height: 145%;
   width: 95%;
-  min-height: 10rem;
+  min-height: ${({ $isReviewMode }) => ($isReviewMode ? '15rem' : '10rem')};
   border: none;
   outline: none;
   padding: 0.5rem;

--- a/src/pages/memoPage/MemoPage.tsx
+++ b/src/pages/memoPage/MemoPage.tsx
@@ -90,7 +90,7 @@ export const MemoPage = () => {
     const newTitle = e.target.value;
     setTempMemo((prev) => ({ ...prev, title: newTitle }));
 
-    if (newTitle.length > 50) {
+    if (newTitle.length > 49) {
       setTitleWarning('50자 이하로 입력해주세요.');
     } else {
       setTitleWarning('');
@@ -184,11 +184,12 @@ export const MemoPage = () => {
           placeholder={getFormattedDate()}
           value={tempMemo.title}
           onChange={handleChangeTitle}
-          maxLength={51}
+          maxLength={49}
           isError={!!titleWarning}
         />
         <S.WarningCountContainer>
           {titleWarning && <S.Warning>{titleWarning}</S.Warning>}
+          <S.Count>{tempMemo.title.length}/50</S.Count>
         </S.WarningCountContainer>
         <S.Line />
         <S.Content


### PR DESCRIPTION
## #️⃣연관된 이슈

>  연관된 이슈 번호를 작성해주세요.
#129

## 📝작업 내용

> 작업한 내용을 작성해주세요.
- 메모 기록 글자수에 따른 warning 추가
- 메모 다시보기 시 임시저장 및 저장 비활성화
- 채팅 다시보기 시 입력창 비활성화
- [4.4] 재요청
- [3.5] 재요청

### 스크린샷 (선택)
![스크린샷 2024-11-21 오후 1 31 22](https://github.com/user-attachments/assets/90ad2c83-a2aa-4d62-8815-16bd3a89479b)
![스크린샷 2024-11-21 오후 1 31 50](https://github.com/user-attachments/assets/a3058477-337a-44de-ac76-606566c4de10)
![스크린샷 2024-11-21 오후 1 32 00](https://github.com/user-attachments/assets/68e25bf1-4320-4493-8e95-236905dbb8ac)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 메모 기록 다시보기 시 아래 경험 폴더 부분은 아예 안보이게 해놓고, 내용 부분 height를 조금 더 늘렸는데 괜찮은지 확인 부탁드립니당..!!
