### PR TITLE
[fix] : 채팅 임시 저장 시 기존 채팅방 삭제 로직 수정

### DIFF
--- a/src/api/Chat.ts
+++ b/src/api/Chat.ts
@@ -83,12 +83,19 @@ export const getChat = async (chatRoomId: number): Promise<ChatHistoryResponse['
 /** [3.4] 채팅 삭제 */
 export const deleteChat = async (chatRoomId: number) => {
   try {
-    const response = await api.delete(`/api/records/chat/${chatRoomId}`);
-    if (response.data.is_success) {
-      return response.data;
+    if (!chatRoomId || isNaN(chatRoomId)) {
+      throw new Error('유효하지 않은 채팅방 ID입니다.');
     }
+
+    const response = await api.delete(`/api/records/chat/${chatRoomId}`);
+
+    if (!response.data.is_success) {
+      throw new Error('채팅 삭제 실패: 성공 응답이 아닙니다.');
+    }
+
+    return response.data;
   } catch (error) {
-    console.error(error);
+    console.error('채팅 삭제 중 오류 발생:', error);
     throw error;
   }
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

>  연관된 이슈 번호를 작성해주세요.
#227 

## 📝작업 내용

> 작업한 내용을 작성해주세요.

- [x] 탭바를 통해 뒤로가기 시 현재 채팅방 삭제
- [x] 임시 저장된 채팅 불러오기 시 해당 chatRoomId url로 이동
- [x] 채팅 다중 임시 저장 허용
- [x] 임시 저장된 채팅방으로 이동 시 새로 생성된 채팅방은 삭제

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
