### PR TITLE
[refactor] : SkillGraph와 SkillList에서 getGraph 중복 호출 제거

### DIFF
--- a/src/components/keyword/skill/SkillGraph.tsx
+++ b/src/components/keyword/skill/SkillGraph.tsx
@@ -1,32 +1,22 @@
-import { useState, useEffect } from 'react';
 import { PieChart, Pie, Cell } from 'recharts';
 import * as S from './SkillGraph.Style';
-import { getGraph } from '@/api/Graph';
 import { SkillData } from '@/types/SkillData';
 import { Colors } from '@/styles/colors';
 
-export const SkillGraph = () => {
-  const [chartData, setChartData] = useState<SkillData[]>([]);
+interface SkillGraphProps {
+  chartData: SkillData[];
+}
 
-  useEffect(() => {
-    const fetchGraphData = async () => {
-      const data = await getGraph();
-      if (data) {
-        const topSkills = data
-          .sort((a: SkillData, b: SkillData) => b.percent - a.percent)
-          .slice(0, 7);
+export const SkillGraph = ({ chartData }: SkillGraphProps) => {
 
-        setChartData(
-          topSkills.map((skill: SkillData) => ({
-            name: skill.keyword,
-            value: skill.count,
-            percent: skill.percent,
-          })),
-        );
-      }
-    };
-    fetchGraphData();
-  }, []);
+  const graphData = chartData
+    .sort((a: SkillData, b: SkillData) => b.percent - a.percent)
+    .slice(0, 7)
+    .map((skill: SkillData) => ({
+      name: skill.keyword,
+      value: skill.count,
+      percent: skill.percent,
+    }));
 
   const getChartColor = (percent: number) => {
     if (percent > 33) return Colors.blue200;
@@ -79,7 +69,7 @@ export const SkillGraph = () => {
     <S.GraphContainer>
       <PieChart width={S.CHART_STYLES.width} height={S.CHART_STYLES.height}>
         <Pie
-          data={chartData}
+          data={graphData}
           innerRadius={S.CHART_STYLES.innerRadius}
           outerRadius={S.CHART_STYLES.outerRadius}
           cornerRadius={S.CHART_STYLES.cornerRadius}
@@ -88,7 +78,7 @@ export const SkillGraph = () => {
           label={renderCustomizedLabel}
           labelLine={false}
         >
-          {chartData.map((entry, index) => (
+          {graphData.map((entry, index) => (
             <Cell key={`cell-${index}`} fill={getChartColor(entry.percent)} />
           ))}
         </Pie>

--- a/src/components/keyword/skill/SkillList.tsx
+++ b/src/components/keyword/skill/SkillList.tsx
@@ -1,9 +1,8 @@
 import * as S from './SkillList.Style';
-import { getGraph } from '@/api/Graph';
 import { SkillData } from '@/types/SkillData';
-import { useState, useEffect } from 'react';
 
 interface SkillListProps {
+  chartData: SkillData[];
   onClick: () => void;
   setSelectedKeyword: React.Dispatch<React.SetStateAction<string | undefined>>;
 }
@@ -14,34 +13,17 @@ interface SkillListProps {
  * @param setSelectedKeyword - setSelectedKeyword
  * @returns
  */
-export const SkillList = ({ onClick, setSelectedKeyword }: SkillListProps) => {
-  const [chartData, setChartData] = useState<SkillData[]>([]);
+export const SkillList = ({ chartData, onClick, setSelectedKeyword }: SkillListProps) => {
 
-  useEffect(() => {
-    const fetchGraphData = async () => {
-      const data = await getGraph();
-      if (data) {
-        const topSkills = data
-          .sort((a: SkillData, b: SkillData) => b.percent - a.percent)
-          .slice(0, 7);
-
-        setChartData(
-          topSkills.map((skill: SkillData) => ({
-            keyword: skill.keyword,
-            count: skill.count,
-            percent: skill.percent,
-          })),
-        );
-      }
-    };
-    fetchGraphData();
-  }, []);
+  const topSkills = chartData
+    .sort((a, b) => b.percent - a.percent)
+    .slice(0, 7);
 
   return (
     <S.Container>
       <S.Line />
       <S.ListItemContainer>
-        {chartData.map((skill) => (
+        {topSkills.map((skill) => (
           <S.ListItem
             key={skill.keyword}
             $percent={skill.percent}

--- a/src/pages/keywordPage/KeywordPage.tsx
+++ b/src/pages/keywordPage/KeywordPage.tsx
@@ -59,8 +59,8 @@ export const KeywordPage = () => {
           <S.Container $isEmpty={chartData.length === 0}>
             {chartData.length > 0 ? (
               <S.Content>
-                <SkillGraph />
-                <SkillList onClick={handleClickSkillList} setSelectedKeyword={setSelectedKeyword} />
+                <SkillGraph chartData={chartData} />
+                <SkillList chartData={chartData} onClick={handleClickSkillList} setSelectedKeyword={setSelectedKeyword} />
               </S.Content>
             ) : (
               <S.EmptyContainer>


### PR DESCRIPTION
## #️⃣연관된 이슈

>  연관된 이슈 번호를 작성해주세요.

## 📝작업 내용

> 작업한 내용을 작성해주세요.

[refactor] : SkillGraph와 SkillList에서 getGraph 중복 호출 제거
- getGraph API 호출을 KeywordPage 상위 컴포넌트로 이동
- chartData를 props로 전달하여 데이터 일관성 유지
- 두 컴포넌트 모두 동일한 데이터를 사용하도록 개선

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
